### PR TITLE
misc(deps): upgraded ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -16,27 +16,27 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cassowary"
@@ -46,18 +46,12 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -67,53 +61,29 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "compact_str"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
 dependencies = [
  "castaway",
- "cfg-if 1.0.0",
+ "cfg-if",
  "itoa",
+ "rustversion",
  "ryu",
  "static_assertions",
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags 2.5.0",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "either"
-version = "1.5.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -121,36 +91,40 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "indoc"
-version = "2.0.4"
+name = "instability"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+dependencies = [
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libpulse-binding"
@@ -158,7 +132,7 @@ version = "2.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3557a2dfc380c8f061189a01c6ae7348354e0c9886038dc6c171219c08eaff"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "libc",
  "libpulse-sys",
  "num-derive",
@@ -181,53 +155,22 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
  "redox_syscall",
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys",
 ]
 
 [[package]]
@@ -252,44 +195,24 @@ dependencies = [
 
 [[package]]
 name = "numtoa"
-version = "0.1.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
 dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
+ "portable-atomic",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pavucontrolrs"
@@ -297,7 +220,6 @@ version = "0.1.1"
 dependencies = [
  "libpulse-binding",
  "ratatui",
- "termion",
 ]
 
 [[package]]
@@ -307,51 +229,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.79"
+name = "portable-atomic"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ratatui"
-version = "0.26.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cassowary",
  "compact_str",
- "crossterm",
- "indoc",
+ "instability",
  "itertools",
  "lru",
  "paste",
- "stability",
  "strum",
+ "strum_macros",
  "termion",
  "unicode-segmentation",
+ "unicode-truncate",
  "unicode-width",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -362,67 +290,15 @@ checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "rustversion"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
-
-[[package]]
-name = "stability"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
-dependencies = [
- "quote",
- "syn 1.0.8",
-]
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "static_assertions"
@@ -432,24 +308,24 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.53",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -465,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -476,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "3.0.0"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417813675a504dfbbf21bfde32c03e5bf9f2413999962b479023c02848c1c7a5"
+checksum = "7eaa98560e51a2cf4f0bb884d8b2098a9ea11ecf3b7078e9c68242c74cc923a7"
 dependencies = [
  "libc",
  "libredox",
@@ -488,21 +364,32 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.6"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -512,15 +399,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "winapi"
@@ -545,87 +426,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.79",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ categories = ["command-line-utilities"]
 [dependencies]
 #cursive = { git = "https://github.com/gyscos/cursive" }
 libpulse-binding = "2.28.1"
-ratatui = { version = "0.26.1", features = ["termion"] }
-termion = "3.0.0"
+ratatui = { version = "0.28.1", features = [
+  "termion",
+], default-features = false }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,4 +1,5 @@
 use std::io;
+use ratatui::termion;
 use termion::event::Key;
 use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
@@ -13,7 +14,7 @@ use ratatui::Terminal;
 use crate::{App, AppView};
 use crate::views;
 
-type FinalTerminal = ratatui::terminal::Terminal<
+type FinalTerminal = ratatui::Terminal<
                      ratatui::backend::TermionBackend<
                      termion::screen::AlternateScreen<
                      termion::input::MouseTerminal<
@@ -56,7 +57,7 @@ pub fn draw_frame<T: ratatui::backend::Backend>(terminal: &mut ratatui::Terminal
             .direction(Direction::Vertical)
             .margin(1)
             .constraints(vec![Constraint::Length(3), Constraint::Length(1), Constraint::Min(0)])
-            .split(f.size());
+            .split(f.area());
 
         Tabs::new(["Sink Inputs", "Source Output", "Sinks", "Sources", "Cards"])
             .block(Block::bordered().title(" Tabs "))
@@ -83,7 +84,7 @@ impl Widget for ClearingWidget {
     fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
         for x in area.left()..area.right() {
             for y in area.top()..area.bottom() {
-                buf.get_mut(x, y).set_symbol(" ");
+                buf[(x, y)].set_symbol(" ");
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use pulse::error::PAErr;
 use pulse::context::subscribe::{Facility, Operation, InterestMaskSet};
 use pulse::volume::{VolumeLinear, ChannelVolumes};
 
+use ratatui::termion;
 use termion::event::Key;
 use termion::input::TermRead;
 

--- a/src/views/cards.rs
+++ b/src/views/cards.rs
@@ -1,4 +1,4 @@
-use termion::event::Key;
+use ratatui::termion::event::Key;
 use ratatui::backend::TermionBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Margin};
 use ratatui::style::{Color, Modifier, Style};
@@ -31,7 +31,7 @@ pub fn entered(app: &mut App) {
     app.card_view_data.close_keybinding_popup();
 }
 
-pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let mut constraints: Vec<ratatui::layout::Constraint> = app.card_list.values().map(|card| Constraint::Length(2 + card.profiles.len() as u16)).collect();
     constraints.push(Constraint::Min(0));
@@ -97,7 +97,7 @@ pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
     }
 }
 
-pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw_keybinding_popup(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let keys = vec![
         ( "F1 through F5", "Change tab"),
@@ -110,7 +110,7 @@ pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, a
         ( "Return", "Confirm profile"),
     ];
 
-    let rect = rect.inner(&Margin::new(4, 4));
+    let rect = rect.inner(Margin::new(4, 4));
     crate::draw::ClearingWidget::default()
         .render(rect, frame.buffer_mut());
 

--- a/src/views/sink_inputs.rs
+++ b/src/views/sink_inputs.rs
@@ -1,4 +1,4 @@
-use termion::event::Key;
+use ratatui::termion::event::Key;
 use ratatui::backend::TermionBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Margin};
 use ratatui::style::{Color, Modifier, Style};
@@ -43,7 +43,7 @@ pub fn entered(app: &mut App) {
     app.sink_input_view_data.close_keybinding_popup();
 }
 
-pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let mut constraints = vec![Constraint::Length(3); app.sink_input_list.len()];
     constraints.push(Constraint::Min(0));
@@ -92,14 +92,14 @@ pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
     }
 }
 
-pub fn draw_sink_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw_sink_popup(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let focused_stream = match app.sink_input_list.get_selected() {
         None => { app.sink_input_view_data.close_sink_popup(); return; },
         Some(x) => x,
     };
 
-    let rect = rect.inner(&Margin::new(4, 4));
+    let rect = rect.inner(Margin::new(4, 4));
     crate::draw::ClearingWidget::default()
         .render(rect, frame.buffer_mut());
 
@@ -127,7 +127,7 @@ pub fn draw_sink_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &m
         }
 }
 
-pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw_keybinding_popup(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let keys = vec![
         ( "F1 through F5", "Change tab"),
@@ -146,7 +146,7 @@ pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, a
         ( "ctrl-k", "Kill all non-running streams"),
     ];
 
-    let rect = rect.inner(&Margin::new(4, 4));
+    let rect = rect.inner(Margin::new(4, 4));
     crate::draw::ClearingWidget::default()
         .render(rect, frame.buffer_mut());
 

--- a/src/views/sinks.rs
+++ b/src/views/sinks.rs
@@ -1,4 +1,4 @@
-use termion::event::Key;
+use ratatui::termion::event::Key;
 use ratatui::backend::TermionBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Margin};
 use ratatui::style::{Color, Modifier, Style};
@@ -33,7 +33,7 @@ pub fn entered(app: &mut App) {
     app.sink_view_data.close_keybinding_popup();
 }
 
-pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let mut constraints = vec![Constraint::Length(3); app.sink_list.len()];
     constraints.push(Constraint::Min(0));
@@ -79,7 +79,7 @@ pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
     }
 }
 
-pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw_keybinding_popup(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let keys = vec![
         ( "F1 through F5", "Change tab"),
@@ -96,7 +96,7 @@ pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, a
         ( "D", "Unload owner module (remove sink)"),
     ];
 
-    let rect = rect.inner(&Margin::new(4, 4));
+    let rect = rect.inner(Margin::new(4, 4));
     crate::draw::ClearingWidget::default()
         .render(rect, frame.buffer_mut());
 

--- a/src/views/source_outputs.rs
+++ b/src/views/source_outputs.rs
@@ -1,4 +1,4 @@
-use termion::event::Key;
+use ratatui::termion::event::Key;
 use ratatui::backend::TermionBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Margin};
 use ratatui::style::{Color, Modifier, Style};
@@ -43,7 +43,7 @@ pub fn entered(app: &mut App) {
     app.source_output_view_data.close_keybinding_popup();
 }
 
-pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let mut constraints = vec![Constraint::Length(3); app.source_output_list. filtered_len(
         |x| !((x.source_index == 0xffffffff || app.source_list.get(x.source_index).map(|x| x.is_monitor()).unwrap_or(false)) && app.hide_monitors)
@@ -106,14 +106,14 @@ pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
     }
 }
 
-pub fn draw_source_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw_source_popup(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let focused_stream = match app.source_output_list.get_selected() {
         None => { app.source_output_view_data.close_source_popup(); return; },
         Some(x) => x,
     };
 
-    let rect = rect.inner(&Margin::new(4, 4));
+    let rect = rect.inner(Margin::new(4, 4));
     crate::draw::ClearingWidget::default()
         .render(rect, frame.buffer_mut());
 
@@ -141,7 +141,7 @@ pub fn draw_source_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: 
         }
 }
 
-pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw_keybinding_popup(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let keys = vec![
         ( "F1 through F5", "Change tab"),
@@ -160,7 +160,7 @@ pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, a
         ( "ctrl-k", "Kill all non-running streams"),
     ];
 
-    let rect = rect.inner(&Margin::new(4, 4));
+    let rect = rect.inner(Margin::new(4, 4));
     crate::draw::ClearingWidget::default()
         .render(rect, frame.buffer_mut());
 

--- a/src/views/sources.rs
+++ b/src/views/sources.rs
@@ -1,4 +1,4 @@
-use termion::event::Key;
+use ratatui::termion::event::Key;
 use ratatui::backend::TermionBackend;
 use ratatui::layout::{Constraint, Direction, Layout, Rect, Margin};
 use ratatui::style::{Color, Modifier, Style};
@@ -33,7 +33,7 @@ pub fn entered(app: &mut App) {
     app.source_view_data.close_keybinding_popup();
 }
 
-pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let mut constraints = vec![Constraint::Length(3); app.source_list.filtered_len(|x| !(x.is_monitor() && app.hide_monitors))];
     constraints.push(Constraint::Min(0));
@@ -87,7 +87,7 @@ pub fn draw(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
     }
 }
 
-pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, app: &mut App) {
+pub fn draw_keybinding_popup(frame: &mut ratatui::Frame, rect: Rect, app: &mut App) {
 
     let keys = vec![
         ( "F1 through F5", "Change tab"),
@@ -104,7 +104,7 @@ pub fn draw_keybinding_popup(frame: &mut ratatui::terminal::Frame, rect: Rect, a
         ( "D", "Unload owner module (remove source)"),
     ];
 
-    let rect = rect.inner(&Margin::new(4, 4));
+    let rect = rect.inner(Margin::new(4, 4));
     crate::draw::ClearingWidget::default()
         .render(rect, frame.buffer_mut());
 


### PR DESCRIPTION
## dependency upgrades

### ratatui

-   with this version, termion is reexported, doesn't have to be added as a seperate dependency
-   removed default-features: less dependencies
-   changed deprecated methods

### termion
